### PR TITLE
unit test book crossing

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -278,7 +278,7 @@ impl From<BidPrice> for Price {
     }
 }
 
-trait HasSide: std::fmt::Debug {
+trait HasSide {
     type OppositePrice: HasSide;
 
     fn side() -> Side;
@@ -552,7 +552,7 @@ where
 
 impl<TPrice> Half<TPrice>
 where
-    TPrice: From<Price> + Ord + std::fmt::Debug,
+    TPrice: From<Price> + Ord,
 {
     /// Adds an order to the halfbook.
     fn add_order_unchecked(&mut self, order: order::Order) {


### PR DESCRIPTION
The unit tests were generated using claude using the following prompt:

> Generate unit tests for `Book::does_order_cross_market` for both ask and bid limit orders. The unit tests should be exhaustive such that all scenarios are checked (orders cross the market,
  orders don't cross the market), and also include the scenario where the book is empty. Always start from an empty book for each test.

These tests revealed that the logic to check for order crossing was not correct because the `HasSide::is_worse_than` logic was wrong and confusing.

It was replaced by `HasSide::crosses` to fix the tests.