### PR TITLE
fix: fully remove order form book on cancellation

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -12,7 +12,7 @@ impl Log {
         Self { events: vec![] }
     }
 
-    /// Returns if the log contains not events.
+    /// Returns `true` the log contains no events.
     pub(crate) fn is_empty(&self) -> bool {
         self.events.is_empty()
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -12,6 +12,11 @@ impl Log {
         Self { events: vec![] }
     }
 
+    /// Returns if the log contains not events.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
     pub(crate) fn push<T>(&mut self, event: T)
     where
         Event: From<T>,
@@ -30,7 +35,7 @@ pub enum Event {
     // FIXME: maybe adding a "Modify" variant and putting it in there together with other modifiers would be sufficient?:w
     Activate(order::Order),
     Add(order::Order),
-    Cancel { id: order::Id },
+    Cancel(Cancel),
     Fill(Fill),
     Match(Match),
 }
@@ -39,6 +44,13 @@ impl Event {
     pub fn as_add(&self) -> Option<&order::Order> {
         match self {
             Self::Add(order) => Some(order),
+            _ => None,
+        }
+    }
+
+    pub fn as_cancel(&self) -> Option<&Cancel> {
+        match self {
+            Event::Cancel(cancel) => Some(cancel),
             _ => None,
         }
     }
@@ -62,12 +74,27 @@ impl Event {
         matches!(self, Event::Add(_))
     }
 
+    pub fn is_cancel(&self) -> bool {
+        matches!(self, Event::Cancel(_))
+    }
+
     pub fn is_fill(&self) -> bool {
         matches!(self, Event::Fill(_))
     }
 
     pub fn is_match(&self) -> bool {
         matches!(self, Event::Match(..))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Cancel {
+    pub id: order::Id,
+}
+
+impl From<Cancel> for Event {
+    fn from(value: Cancel) -> Self {
+        Self::Cancel(value)
     }
 }
 


### PR DESCRIPTION
Orders were not removed from the index mapping order IDs to halfbook/side/price level, which was violation of invariants.

This PR was generated by prompting Claude Code. The generated changes were then manually simplified.

The prompts used:

> Go through the codebase and find bugs.

The previous command created a todo list with the following entry:

### 1. Fix critical cancel method bug - missing HashMap removal **File**: `src/book.rs` (lines 664-674)
**Issue**: The `cancel` method doesn't remove the order from `id_to_side_and_price` HashMap, causing memory leaks and state inconsistency. **Impact**: Memory leak, prevents order ID reuse, `contains()` returns true for cancelled orders.

> Write the TODO list to a TODO.md file.

> Provide a fix and unit test for the first point on your todo list.

> Fix the critical cancel method, but instead of using HashMap::remove after removing from the halfbooks, replace HashMap::get by HashMap::remove before delegating to the halfbooks.

> Don't rename order to test_order. It's clear from context that it's a test order.