### PR TITLE
chore: don't pass a mutable reference where it's not necessary

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -822,7 +822,7 @@ impl Book {
                         &mut ask,
                         log,
                         // XXX: need to construct the callback closure in the loop because we need to be able to insert the stop order into the map right after.
-                        &mut make_remove_fn(&mut self.id_to_side_and_price),
+                        make_remove_fn(&mut self.id_to_side_and_price),
                     );
 
                     if ask.is_filled() || ask.is_immediate() {


### PR DESCRIPTION
This patch was generated from a claude prompt for
a bug that it found in a previous call, see
https://github.com/astriaorg/clobbered/pull/9 for
how the bug was found. Actual finding:

### 1. Fix inconsistent reference in stop order activation **File**: `src/book.rs` (lines 821-826)
**Issue**: Inconsistent parameter passing to `perform_match` - one call uses `&mut` and another doesn't. **Impact**: Compilation errors and inconsistent behavior in stop order activation.

Prompts to fix the bug

> Show me how you would fix the next point on the TODO list.

> Make the change because it's better, but your reasoning is wrong. It does not cause
  compilation failure, does not break activation, and does also not exhibit inconsistent
  behavior. It's merely a stylistic inconsistency.