### PR TITLE
Set price of stop order

### DIFF
--- a/src/book.rs
+++ b/src/book.rs
@@ -427,7 +427,7 @@ where
 
 impl<TPrice> Half<TPrice>
 where
-    TPrice: AsRef<Price> + Copy + From<Price> + Into<Price> + HasSide + Ord,
+    TPrice: AsRef<Price> + Copy + Into<Price> + HasSide + Ord,
     TPrice::OppositePrice: From<Price>,
 {
     /// Executes `order` against the book.

--- a/src/book.rs
+++ b/src/book.rs
@@ -466,9 +466,7 @@ where
         match order.type_ {
             order::Type::Stop => {
                 order.type_ = order::Type::Market;
-                if order.has_slippage() {
-                    market_price = *order.stop_price();
-                } else {
+                if !order.has_slippage() {
                     market_price = *TPrice::worst_possible().as_ref();
                 }
             }

--- a/src/order.rs
+++ b/src/order.rs
@@ -468,28 +468,9 @@ impl Order {
         self.type_.is_stop()
     }
 
-    /// Sets the market price of the order, taking into accounts its side and slippage setting.
-    ///
-    /// If the order does not have slippage set, then its market price will be set to the maximum
-    /// possible value (maximum if a bid, minimum if an ask). If it has slippage set, then its
-    /// market price will be set to `market_price +/- slippage` (the slippage is added if a bid,
-    /// subtracted if an ask).
-    ///
-    /// The caller is responsible for ensuring that the order is indeed a market order because
-    /// this call otherwise does not make sense.
-    pub fn set_market_price_considering_slippage(&mut self, market_price: &Price) {
-        let order_price = if let Some(slippage) = self.slippage {
-            match self.side {
-                Side::Ask => market_price.minus_slippage(&slippage),
-                Side::Bid => market_price.plus_slippage(&slippage),
-            }
-        } else {
-            match self.side {
-                Side::Ask => Price::zero(),
-                Side::Bid => Price::max(),
-            }
-        };
-        self.price = order_price;
+    /// Sets the order price to [`price`].
+    pub fn set_price(&mut self, price: Price) {
+        self.price = price;
     }
 
     /// Returns if the order has slippage set.


### PR DESCRIPTION
This fix was generated using Claude Code for the following bug it
previously found (see https://github.com/astriarg/clobbered/pull/9 for
context).

> ### 1. Fix stop order market price calculation with slippage
> **File**: `src/book.rs` (lines 467-474)
> **Issue**: Stop orders with slippage use stop price instead of current market price.
> **Impact**: Orders execute at wrong price, potential financial losses.

## Prompts:

> Fix the next item on the TODO list. You have stored it in TODO.md.

> Perform the last suggested change, but don't add the comment.

---

The fix is correct in that setting the price of the stop-order to its stop-price and adding/subtracting slippage is at best confusing and at worst incorrect: this is the same as a stop-limit order with a time-in-force of immediate-or-cancel and the post-activation price set to the stop-price +/- slippage.

The patch removes `Order::set_market_price_considering_slippage` in favor a `Order::set_price` called during the order execution.