### PR TITLE
Add multi-symbol support to orderbook engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,19 @@ name = "clobbered"
 version = "0.1.0"
 dependencies = [
  "thiserror",
+ "tinystr",
  "uuid",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -111,6 +123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,4 +164,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "zerofrom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 thiserror = "2.0.12"
+tinystr = "0.8.1"
 uuid = { version = "1.17.0", default-features = false, features = ["v6"] }
 
 [dev-dependencies]

--- a/src/book.rs
+++ b/src/book.rs
@@ -1,8 +1,4 @@
-use crate::{
-    level::Level,
-    order::{Side, Slippage},
-    transaction::Event,
-};
+use crate::{level::Level, order::Side, transaction::Event};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::{
@@ -575,6 +571,7 @@ where
 /// A price-time orderbook.
 #[derive(Debug)]
 pub struct Book {
+    symbol: order::Symbol,
     asks: Half<AskPrice>,
     bids: Half<BidPrice>,
 
@@ -593,8 +590,9 @@ pub struct Book {
 
 impl Book {
     /// Creates a new order book.
-    pub fn new() -> Self {
+    pub fn new(symbol: order::Symbol) -> Self {
         Self {
+            symbol,
             asks: Half::new(),
             bids: Half::new(),
             id_to_side_and_price: HashMap::new(),
@@ -620,6 +618,8 @@ impl Book {
         mut order: order::Order,
         log: &mut transaction::Log,
     ) -> Result<(), AddOrderError> {
+        debug_assert_eq!(self.symbol, *order.symbol());
+        
         if self.contains(order.id()) {
             return Err(AddOrderError::IdAlreadyExists(order));
         }
@@ -946,11 +946,6 @@ impl Book {
     }
 }
 
-impl Default for Book {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 // utility to create a closure that is passed to the various matching functions to
 // remove orders in the higher-level id-to-side-and-price map (to avoid needing a
@@ -970,18 +965,23 @@ mod tests {
 
     use super::{AskPrice, BidPrice, Book, HasSide, PriceToLevel};
     use crate::{
-        order::{Id, Order, Price, Quantity, Side, Type},
+        order::{Id, Order, Price, Quantity, Side, Symbol, Type},
         transaction::{self, Event, Fill, Log},
     };
 
     fn order() -> Order {
         Order::builder()
             .id(Id::new(Uuid::new_v4()))
+            .symbol(Symbol::new("BTCUSD").unwrap())
             .quantity(Quantity::new(10))
             .price(Price::new(5))
             .side(Side::Ask)
             .build()
             .unwrap()
+    }
+
+    fn book() -> Book {
+        Book::new(Symbol::new("BTCUSD").unwrap())
     }
 
     #[test]
@@ -1006,7 +1006,7 @@ mod tests {
         // scenario: the orderbook is empty, a limit order comes in
         //
         // expected result: the limit order is added to the book.
-        let mut book = Book::new();
+        let mut book = book();
         let id = Id::new(uuid::Uuid::new_v4());
         let price = Price::new(10);
         let side = Side::Bid;
@@ -1041,7 +1041,7 @@ mod tests {
         //
         // expected result: the market order is passed through and left
         // completely unfilled.
-        let mut book = Book::new();
+        let mut book = book();
         let id = Id::new(uuid::Uuid::new_v4());
         let side = Side::Bid;
         let type_ = Type::Market;
@@ -1079,7 +1079,7 @@ mod tests {
         //
         // expected result: the market order is partially filled at the price of the ask
         // order, the ask order limit order is completely filled.
-        let mut book = Book::new();
+        let mut book = book();
         let ask_id = Id::new(uuid::Uuid::new_v4());
         let ask_quantity = Quantity::new(9);
         let ask_price = Price::new(5);
@@ -1163,7 +1163,7 @@ mod tests {
         // expected result: the market order is completely filled. The ask order
         // at the lower price is completey filled. The ask order at the higher price
         // is partially filled.
-        let mut book = Book::new();
+        let mut book = book();
 
         let cheap_id = Id::new(uuid::Uuid::new_v4());
         let expensive_id = Id::new(uuid::Uuid::new_v4());
@@ -1243,7 +1243,7 @@ mod tests {
         // expected result: the stop order should be tracked by the book,
         // but it should not be considered as executable/affect the price
         // of its side.
-        let mut book = Book::new();
+        let mut book = book();
         let id = Id::new(uuid::Uuid::new_v4());
         let price = Price::new(10);
         let stop_price = Price::new(11);
@@ -1277,7 +1277,7 @@ mod tests {
         //
         // expected result: the stop limit order becomes a limit order on the book. both orders now
         // sit in the book. No matches between the two orders happen.
-        let mut book = Book::new();
+        let mut book = book();
         let id = Id::new(uuid::Uuid::new_v4());
         let mut log = Log::new();
         book.execute(
@@ -1326,7 +1326,7 @@ mod tests {
         // scenario: empty book, ask order comes in
         //
         // expected result: ask order does not cross the market (no bids to cross)
-        let book = Book::new();
+        let book = book();
         let ask_order = Order {
             side: Side::Ask,
             price: Price::new(100),
@@ -1340,7 +1340,7 @@ mod tests {
         // scenario: empty book, bid order comes in
         //
         // expected result: bid order does not cross the market (no asks to cross)
-        let book = Book::new();
+        let book = book();
         let bid_order = Order {
             side: Side::Bid,
             price: Price::new(100),
@@ -1354,7 +1354,7 @@ mod tests {
         // scenario: bid at 100 on book, ask order comes in at 90
         //
         // expected result: ask order crosses the market (ask price < bid price)
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
         book.execute(
             Order {
@@ -1379,7 +1379,7 @@ mod tests {
         // scenario: bid at 100 on book, ask order comes in at 100
         //
         // expected result: ask order crosses the market (ask price = bid price)
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
         book.execute(
             Order {
@@ -1404,7 +1404,7 @@ mod tests {
         // scenario: bid at 100 on book, ask order comes in at 110
         //
         // expected result: ask order should NOT cross (ask price > bid price)
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
         book.execute(
             Order {
@@ -1430,7 +1430,7 @@ mod tests {
         // scenario: ask at 100 on book, bid order comes in at 110
         //
         // expected result: bid order crosses the market (bid price > ask price)
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
         book.execute(
             Order {
@@ -1455,7 +1455,7 @@ mod tests {
         // scenario: ask at 100 on book, bid order comes in at 100
         //
         // expected result: bid order crosses the market (bid price = ask price)
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
         book.execute(
             Order {
@@ -1480,7 +1480,7 @@ mod tests {
         // scenario: ask at 100 on book, bid order comes in at 90
         //
         // expected result: bid order should NOT cross (bid price < ask price)
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
         book.execute(
             Order {
@@ -1506,7 +1506,7 @@ mod tests {
         // scenario: multiple bids on book (90, 95, 100), ask order comes in at 92
         //
         // expected result: ask order crosses the market (crosses the best bid at 100)
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
 
         // Add multiple bids
@@ -1551,7 +1551,7 @@ mod tests {
         // scenario: multiple asks on book (100, 105, 110), bid order comes in at 108
         //
         // expected result: bid order crosses the market (crosses the best ask at 100)
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
 
         // Add multiple asks
@@ -1598,7 +1598,7 @@ mod tests {
         // expected result: the operation returns the the order was cancelled.
         // A cancellation event is found in the log. A subsequent cancel returns
         // that no order was cancelled.
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
 
         let order_id = Id::new(uuid::Uuid::new_v4());
@@ -1629,7 +1629,7 @@ mod tests {
         // scenario: attempt to cancel an order that was never added to the book
         //
         // expected result: cancel returns false and no events are logged
-        let mut book = Book::new();
+        let mut book = book();
         let mut log = Log::new();
         let nonexistent_id = Id::new(uuid::Uuid::new_v4());
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,8 +1,10 @@
 use crate::{order, transaction};
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub enum ExecutionError {
     AddOrder(Box<crate::book::AddOrderError>),
+    UnknownSymbol(order::Symbol),
 }
 
 impl From<crate::book::AddOrderError> for ExecutionError {
@@ -11,23 +13,28 @@ impl From<crate::book::AddOrderError> for ExecutionError {
     }
 }
 
-/// A match engine tracks a list of orderbooks.
-///
-/// For now, only one order book is tracked (the engine does not know about symbols).
+/// A match engine tracks multiple orderbooks, one per symbol.
 pub struct MatchEngine {
-    the_order_book: crate::book::Book,
+    orderbooks: HashMap<order::Symbol, crate::book::Book>,
 }
 
 impl MatchEngine {
     pub fn new() -> Self {
         Self {
-            the_order_book: crate::book::Book::new(),
+            orderbooks: HashMap::new(),
         }
+    }
+
+    pub fn add_orderbook(&mut self, symbol: order::Symbol) {
+        self.orderbooks.insert(symbol, crate::book::Book::new(symbol));
     }
 
     pub fn add_order(&mut self, order: order::Order) -> Result<transaction::Log, ExecutionError> {
         let mut log = transaction::Log::new();
-        self.the_order_book.execute(order, &mut log)?;
+        let symbol = *order.symbol();
+        let book = self.orderbooks.get_mut(&symbol)
+            .ok_or_else(|| ExecutionError::UnknownSymbol(symbol))?;
+        book.execute(order, &mut log)?;
         Ok(log)
     }
 }
@@ -35,5 +42,49 @@ impl MatchEngine {
 impl Default for MatchEngine {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::order::{Id, Price, Quantity, Side, Symbol};
+    use uuid::Uuid;
+
+    #[test]
+    fn rejects_orders_for_unknown_symbols() {
+        let mut engine = MatchEngine::new();
+        let btc_symbol = Symbol::new("BTCUSD").unwrap();
+        let eth_symbol = Symbol::new("ETHUSD").unwrap();
+        
+        // Add orderbook for BTC only
+        engine.add_orderbook(btc_symbol);
+        
+        // BTC order should succeed
+        let btc_order = order::Order::builder()
+            .id(Id::new(Uuid::new_v4()))
+            .symbol(btc_symbol)
+            .price(Price::new(50000))
+            .quantity(Quantity::new(100))
+            .side(Side::Ask)
+            .build()
+            .unwrap();
+        
+        assert!(engine.add_order(btc_order).is_ok());
+        
+        // ETH order should fail with UnknownSymbol
+        let eth_order = order::Order::builder()
+            .id(Id::new(Uuid::new_v4()))
+            .symbol(eth_symbol)
+            .price(Price::new(3000))
+            .quantity(Quantity::new(100))
+            .side(Side::Ask)
+            .build()
+            .unwrap();
+        
+        match engine.add_order(eth_order) {
+            Err(ExecutionError::UnknownSymbol(symbol)) => assert_eq!(symbol, eth_symbol),
+            _ => panic!("Expected UnknownSymbol error"),
+        }
     }
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -271,10 +271,11 @@ impl<'level> Iterator for OrdersMut<'level> {
 #[cfg(test)]
 mod tests {
     use super::Level;
-    use crate::order::{Id, Order, Price, Quantity, Side};
+    use crate::order::{Id, Order, Price, Quantity, Side, Symbol};
 
     fn order() -> Order {
         Order::builder()
+            .symbol(Symbol::new("BTCUSD").unwrap())
             .quantity(Quantity::new(10))
             .price(Price::new(5))
             .side(Side::Ask)

--- a/src/order.rs
+++ b/src/order.rs
@@ -1,8 +1,35 @@
 #[derive(Debug, PartialEq, Eq)]
-pub enum Error {
+pub struct Error(ErrorKind);
+
+impl Error {
+    fn invalid_symbol(err: tinystr::ParseError) -> Self {
+        Self(ErrorKind::InvalidSymbol(err))
+    }
+
+    fn no_price() -> Self {
+        Self(ErrorKind::NoPrice)
+    }
+
+    fn no_side() -> Self {
+        Self(ErrorKind::NoSide)
+    }
+
+    fn no_stop_price() -> Self {
+        Self(ErrorKind::NoStopPrice)
+    }
+
+    fn no_symbol() -> Self {
+        Self(ErrorKind::NoSymbol)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ErrorKind {
+    InvalidSymbol(tinystr::ParseError),
     NoPrice,
     NoSide,
     NoStopPrice,
+    NoSymbol,
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -11,6 +38,24 @@ pub struct Id(uuid::Uuid);
 impl Id {
     pub fn new(uuid: uuid::Uuid) -> Self {
         Self(uuid)
+    }
+}
+
+/// A trading symbol (up to 8 ASCII characters).
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Symbol(tinystr::TinyAsciiStr<8>);
+
+impl Symbol {
+    /// Creates a new symbol from a string slice.
+    pub fn new(s: &str) -> Result<Self, Error> {
+        let tiny_str = tinystr::TinyAsciiStr::try_from_str(s).map_err(Error::invalid_symbol)?;
+        Ok(Self(tiny_str))
+    }
+
+    /// Returns the symbol as a string slice.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
     }
 }
 
@@ -218,6 +263,7 @@ pub enum TimeInForce {
 
 pub struct Builder {
     id: Id,
+    symbol: Option<Symbol>,
     type_: Type,
     time_in_force: TimeInForce,
     side: Option<Side>,
@@ -232,6 +278,7 @@ impl Builder {
     pub fn new() -> Self {
         Self {
             id: Id::new(uuid::Uuid::nil()),
+            symbol: None,
             type_: Type::Limit,
             time_in_force: TimeInForce::GoodTillCanceled,
             side: None,
@@ -245,6 +292,10 @@ impl Builder {
 
     pub fn id(self, id: Id) -> Self {
         Self { id, ..self }
+    }
+
+    pub fn symbol(self, symbol: Symbol) -> Self {
+        Self { symbol: Some(symbol), ..self }
     }
 
     pub fn type_(self, type_: Type) -> Self {
@@ -297,6 +348,7 @@ impl Builder {
     pub fn build(self) -> Result<Order, Error> {
         let Self {
             id,
+            symbol,
             type_,
             time_in_force,
             side,
@@ -306,8 +358,9 @@ impl Builder {
             slippage,
             post_only,
         } = self;
-        let side = side.ok_or(Error::NoSide)?;
-        let price = price.ok_or(Error::NoPrice)?;
+        let symbol = symbol.ok_or_else(Error::no_symbol)?;
+        let side = side.ok_or_else(Error::no_side)?;
+        let price = price.ok_or_else(Error::no_price)?;
 
         // XXX: For stop orders The stop price must be set. Otherwise the value itself
         // doesn't matter and is just passed through (the orderbook will not look at it).
@@ -319,10 +372,11 @@ impl Builder {
                     Some(Price::zero())
                 }
             })
-            .ok_or(Error::NoStopPrice)?;
+            .ok_or_else(Error::no_stop_price)?;
 
         Ok(Order {
             id,
+            symbol,
             type_,
             time_in_force,
             side,
@@ -340,6 +394,8 @@ impl Builder {
 pub struct Order {
     /// The ID assigned to the order upon entering the system.
     pub(crate) id: Id,
+    // The trading symbol for this order
+    pub(crate) symbol: Symbol,
     // The type of order (market, limit, etc)
     //
     // NOTE: type is a reserved keyword in rust, hence we call this field type_.
@@ -381,6 +437,10 @@ impl Order {
 
     pub fn id(&self) -> &Id {
         &self.id
+    }
+
+    pub fn symbol(&self) -> &Symbol {
+        &self.symbol
     }
 
     pub fn price(&self) -> &Price {
@@ -495,29 +555,36 @@ impl Order {
 
 #[cfg(test)]
 mod tests {
-    use super::{Error, Order, Price, Side, Type};
+    use super::{Error, Order, Price, Side, Symbol, Type};
 
     #[test]
     fn orders_must_have_a_side_set() {
         assert_eq!(
-            Err(Error::NoSide),
-            Order::builder().price(Price::new(5)).build(),
+            Err(Error::no_side()),
+            Order::builder()
+                .symbol(Symbol::new("BTCUSD").unwrap())
+                .price(Price::new(5))
+                .build(),
         );
     }
 
     #[test]
     fn orders_must_have_a_price_set() {
         assert_eq!(
-            Err(Error::NoPrice),
-            Order::builder().side(Side::Ask).build(),
+            Err(Error::no_price()),
+            Order::builder()
+                .symbol(Symbol::new("BTCUSD").unwrap())
+                .side(Side::Ask)
+                .build(),
         );
     }
 
     #[test]
     fn stop_orders_must_have_stop_price_set() {
         assert_eq!(
-            Err(Error::NoStopPrice),
+            Err(Error::no_stop_price()),
             Order::builder()
+                .symbol(Symbol::new("BTCUSD").unwrap())
                 .type_(Type::Stop)
                 .price(Price::new(5))
                 .side(Side::Ask)


### PR DESCRIPTION
## Summary

Add support for multiple trading symbols to the orderbook engine, with each symbol having its own dedicated orderbook.

## Changes

- **Symbol type**: Added `Symbol` newtype wrapper around `TinyAsciiStr<8>` (up to 8 ASCII chars)
- **Order updates**: Orders now require a symbol field with proper validation
- **Multi-symbol engine**: `MatchEngine` now manages multiple orderbooks using `HashMap<Symbol, Book>`
- **Book symbol tracking**: Each `Book` stores its symbol with debug assertion for safety
- **API changes**: `Book::new(symbol)` and `MatchEngine::add_orderbook(symbol)` required

## Breaking Changes

- `Book::new()` now requires a `symbol` parameter
- `Order::builder()` requires `.symbol()` call during construction  
- `MatchEngine::add_orderbook()` must be called before adding orders for unknown symbols
- Removed `Book::Default` implementation

## Test Coverage

- All existing tests updated to work with symbols
- Added integration test for multi-symbol functionality
- Debug assertions prevent symbol mismatches during development

This enables building trading systems that handle multiple instruments while avoiding heap allocations through `TinyAsciiStr<8>`.

🤖 Generated with [Claude Code](https://claude.ai/code)